### PR TITLE
Filter out instance info with pre-installed software

### DIFF
--- a/bin/instance_details.js
+++ b/bin/instance_details.js
@@ -86,12 +86,13 @@ async function getInstanceDetails () {
     const region = regionMap[serviceDetails['location']] ? regionMap[serviceDetails['location']] : serviceDetails['location']
     const operatingSystem = serviceDetails['operatingSystem']
     const tenancy = serviceDetails['tenancy']
+    const preInstalledSw = serviceDetails['preInstalledSw']
 
     if (!instances[instanceType]['regions'].includes(region)) {
       instances[instanceType]['regions'].push(region)
     }
 
-    if (operatingSystem !== 'NA' && tenancy !== 'Host' && json.terms.OnDemand[sku]) {
+    if (operatingSystem !== 'NA' && tenancy !== 'Host' && preInstalledSw == 'NA' && json.terms.OnDemand[sku]) {
       const priceBlock = json.terms.OnDemand[sku]
       const offerCodes = Object.keys(priceBlock)
       const offerCode = offerCodes[0]


### PR DESCRIPTION
AWS added info/pricing for Linux instances with SQL
Server installed, which is significantly more expensive
than the base instance. Therefore we should exclude
these for determining the pricing of the instance.